### PR TITLE
Security fix to prevent logging password

### DIFF
--- a/middleware/session_config.go
+++ b/middleware/session_config.go
@@ -83,7 +83,7 @@ func (c *UserPasswordCredential) prepare(s Middleware) (interface{}, error) {
 
 	_, _, err := s.Execute(fmt.Sprintf("$%s = ConvertTo-SecureString -String %s -AsPlainText -Force", pwname, utils.QuoteArg(c.Password)))
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not convert password to secure string")
+		return nil, errors.New("Could not convert password to secure string")
 	}
 
 	_, _, err = s.Execute(fmt.Sprintf("$%s = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList %s, $%s", name, utils.QuoteArg(c.Username), pwname))


### PR DESCRIPTION
Fix bug that caused plaintext password to be logged in case of error establishing PS session.